### PR TITLE
Add generate_random_salt.sh script

### DIFF
--- a/reunion/dist/Readme.tpl
+++ b/reunion/dist/Readme.tpl
@@ -24,16 +24,18 @@ INSTALLATION:
 		or this for linux
 			linux addons/reunion/reunion_mm_i386.so
 		at the beginning of the file
-	4. Copy reunion.cfg to server root or gamedir.
-	5. Start the server. When server loads, type "meta list" in console. You'll see something like this:
+	4. Enter a 16-64 length random alphanumerical string to "SteamIdHashSalt=" option in reunion.cfg.
+		Or you can use generate_random_salt.sh script to do this automatically.
+	5. Copy reunion.cfg to server root or gamedir.
+	6. Start the server. When server loads, type "meta list" in console. You'll see something like this:
 
 		Currently loaded plugins:
 		      description      stat pend  file              vers      src   load  unlod
 		 [ 1] Reunion          RUN   -    reunion_mm_i386.  v${APP_VERSION_STRD} ini   Start Never
 		 [ 2] AMX Mod X        RUN   -    amxmodx_mm_i386.  v1.8.1.3  ini   Start ANY
 		2 plugins, 2 running
-	6. If status is not "RUN", start server with "+log on +mp_logecho 1" parameters and look through console output. In 99% cases you'll find reason there.
-	7. Installation of AmxModX plugins from amxx directory is not necessary.
+	7. If status is not "RUN", start server with "+log on +mp_logecho 1" parameters and look through console output. In 99% cases you'll find reason there.
+	8. Installation of AmxModX plugins from amxx directory is not necessary.
 
 HOW TO CHANGE STEAMIDS OF CLIENTS
 	Use cid* options in AUTHID MANAGEMENT section of reunion.cfg

--- a/reunion/dist/generate_random_salt.sh
+++ b/reunion/dist/generate_random_salt.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+
+_fail () {
+    echo $'Could not generate salt automatically.\nPlease enter a 16-64 length random alphanumerical string to "SteamIdHashSalt=" option in reunion.cfg.'
+    return 1
+}
+
+_success() {
+    if grep -e ^"SteamIdHashSalt\s*=" reunion.cfg 2>&1 >/dev/null; then
+        sed -i "s/SteamIdHashSalt\s*=.*/SteamIdHashSalt = $SALT/g" reunion.cfg 2>&1 >/dev/null
+    else
+        echo "SteamIdHashSalt = $SALT" >> reunion.cfg
+    fi
+    if ! grep ^"SteamIdHashSalt = $SALT" reunion.cfg 2>&1 >/dev/null; then
+        echo [fail]
+        _fail
+        return 1
+    fi
+    echo [ok]
+    echo "Done. \"SteamIdHashSalt = $SALT\" generated successfully and written to reunion.cfg."
+    return 0
+}
+
+SALT=
+
+if [ ! -f reunion.cfg ]; then
+    echo Error: reunion.cfg does not exist in the current directory!
+    exit 1
+fi
+
+echo -n "Testing for grep ... "
+if ! command -v grep 2>&1 >/dev/null; then
+    echo [fail]
+    _fail
+    exit 1
+fi
+echo [ok]
+
+echo -n "Testing for wc ... "
+if ! command -v wc 2>&1 >/dev/null; then
+    echo [fail]
+    _fail
+    exit 1
+fi
+echo [ok]
+
+echo -n "Testing for sed ... "
+if ! command -v sed 2>&1 >/dev/null; then
+    echo [fail]
+    _fail
+    exit 1
+fi
+echo [ok]
+
+echo -n "Testing for openssl ... "
+if command -v openssl 2>&1 >/dev/null; then
+    echo [ok]
+    echo -n "Generating salt ... "
+    SALT="$(openssl rand -hex 16)"
+    if [ "$(echo "$SALT" | wc -c)" -gt 31 ]; then
+        _success
+        exit $?
+    else
+        echo [fail]
+    fi
+else
+    echo [not found]
+fi
+
+echo -n "Testing for /dev/urandom ... "
+if [ ! -e /dev/urandom ]; then
+    echo [fail]
+    _fail
+    exit 1
+fi
+echo [ok]
+
+echo -n "Testing for hexdump ... "
+if command -v hexdump 2>&1 >/dev/null; then
+    echo [ok]
+    echo -n "Generating salt ... "
+    SALT="$(hexdump -vn16 -e'4/4 "%08x"' /dev/urandom)"
+    if [ "$(echo "$SALT" | wc -c)" -gt 31 ]; then
+        _success
+        exit $?
+    else
+        echo [fail]
+    fi
+else
+    echo [not found]
+fi
+
+echo -n "Testing for xxd ... "
+if command -v xxd 2>&1 >/dev/null; then
+    echo [ok]
+    echo -n "Generating salt ... "
+    SALT="$(xxd -l 16 -p /dev/urandom)"
+    if [ "$(echo "$SALT" | wc -c)" -gt 31 ]; then
+        _success
+        exit $?
+    else
+        echo [fail]
+    fi
+else
+    echo [not found]
+fi
+
+echo -n "Testing for tr ... "
+if command -v tr 2>&1 >/dev/null; then
+    echo [ok]
+    echo -n "Generating salt ... "
+    SALT="$(tr -dc 'a-f0-9' < /dev/urandom | head -c32)"
+    if [ "$(echo "$SALT" | wc -c)" -gt 31 ]; then
+        _success
+        exit $?
+    else
+        echo [fail]
+    fi
+else
+    echo [not found]
+fi
+_fail
+exit 1
+


### PR DESCRIPTION
As pointed out in #1 and #4 , the addition of SteamIdHashSalt has confused some users.

To help users I added a script 'generate_random_salt.sh' to automatically generate a random 32-length hexadecimal string and write it to reunion.cfg.
It's also helpful for hlds container autoconfiguration scripts and the like.
Also changed the Readme to reflect this.

The script should be compatible with pretty much any distro out there as it requires tools that should exist in any of them: grep, wc, sed plus one of openssl / hexdump / xxd / tr.
The script checks for the existence of these tools and chooses the correct one or fails gracefully if it cannot find them.

The script is a good stopgap solution but further on it could be considered that if SteamIdHashSalt is left blank, ReUnion would automatically create a random salt and write it to reunion.cfg.
This is as simple as reading random bytes from /dev/urandom on Linux or using [advapi32:SystemFunction036()](https://github.com/anzz1/fenc/blob/24b1de257a3891b065504f290b4fd483c0caa742/fenc.c#L259) on Windows (SystemFunction036 is supported by WinXP/Server2003 and up, so on earlier Windows it could still fall back to the original error message).
