### PR TITLE
auto-generate random SteamIdHashSalt if the field is left blank

### DIFF
--- a/reunion/src/osconf.h
+++ b/reunion/src/osconf.h
@@ -17,6 +17,7 @@
 	#define rotr _rotr
 	#define rotl64 _rotl64
 	#define rotr64 _rotr64
+	#define ftruncate _chsize
 
 #else //WIN32
 	#include <arpa/inet.h>
@@ -26,6 +27,7 @@
 	#include <netinet/in.h>
 	#include <sys/sysinfo.h>
 	#include <sys/time.h>
+
 	#define NOINLINE __attribute__((noinline))
 
 	inline uint32_t rotl(uint32_t x, int r)

--- a/reunion/src/reunion_cfg.h
+++ b/reunion/src/reunion_cfg.h
@@ -62,6 +62,7 @@ private:
 public:
 	bool load(FILE *fl);
 	static CReunionConfig* createDefault();
+	static FILE* open(const char* fname, const char* fmode);
 	static FILE* open(const char* fname);
 
 	bool parseCfgParam();


### PR DESCRIPTION
Continuing #8 , added the feature proposed there, that is auto-generating a random SteamIdHashSalt in case the field is left blank.
Will save the result in reunion.cfg so this should only happen once.
If the generation fails for some reason like unable to generate random entropy, reunion.cfg is write-protected or otherwise don't have write access, etc. it falls back to the original error message. Returning success only when the generation and writing the config file is successful should make sure that the user can't be stuck in a situation where a new random salt would be created each restart.

I also avoided any additional headers or using any non-standard functions to keep the code as portable as possible.


