### PR TITLE
Fix PatchVersion parsing in server_info.cpp

### DIFF
--- a/reunion/src/server_info.cpp
+++ b/reunion/src/server_info.cpp
@@ -702,8 +702,9 @@ void CServerInfo::parseAppVersion(char* buf, size_t maxlen)
 			trimbuf(line);
 			trimbuf(value);
 
-			if (!strcmp(line, "PatchVersion=")) {
+			if (!strcmp(line, "PatchVersion")) {
 				snprintf(buf, maxlen, "%s/Stdio", value);
+				buf[maxlen] = 0;
 				break;
 			}
 		}


### PR DESCRIPTION
The `*value++ = '\0';` line removes the `=` character which made the `if (!strcmp(line, "PatchVersion=")) {` never find it and thus never match.
